### PR TITLE
Remove hard coded client endpoint

### DIFF
--- a/src/utils/Types.ts
+++ b/src/utils/Types.ts
@@ -8,9 +8,10 @@ export type Connection = {
   events: LimitedArray;
 };
 
-// export const endpoint = `${window.location.protocol}//${window.location.host}${window.location.pathname.replace(/\/+$/, '')}`;
-export const endpoint = "http://localhost:2567"
-export const client = new Client(endpoint);
+export const baseEndpoint = `${window.location.protocol}//${window.location.host}`;
+export const endpoint = `${baseEndpoint}${window.location.pathname.replace(/\/+$/, '')}`;
+
+export const client = new Client(baseEndpoint);
 
 export const global = { connections: [] as Connection[], };
 


### PR DESCRIPTION
Changes:
- Remove hard coded `endpoint` constant.
- Introduced new constant, `baseEndpoint` designated as the URL for the Client instance. An issue surfaced when endpoint from previous release was used as the Client's endpoint where matchmaker requests would include playground's path, resulting connection issues.
- Adjusted the `Client` to utilize the updated `baseEndpoint`.