### PR TITLE
Added `crossorigin="use-credentials"` to manifest link tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,8 +13,10 @@
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+
+      `crossorigin="use-credentials"` for when you locked this page behind an authenticated route
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Added `crossorigin="use-credentials"` to manifest link tag, because else if you have the playground behind an authenticated route, then it will give an 401 error.