### PR TITLE
Add dynamic prefix path detection for client initialization

### DIFF
--- a/src/utils/Types.ts
+++ b/src/utils/Types.ts
@@ -11,10 +11,10 @@ export type Connection = {
 export const baseEndpoint = `${window.location.protocol}//${window.location.host}`;
 export const endpoint = `${baseEndpoint}${window.location.pathname.replace(/\/+$/, '')}`;
 
-export const client = new Client(baseEndpoint);
+const prefixPathMatch = window.location.pathname.match(/\/([^/]+)\/playground/);
+const prefixPath = prefixPathMatch ? `/${prefixPathMatch[1]}` : '';
 
-// export const endpoint = "http://localhost:2567/playground";
-// export const client = new Client("http://localhost:2567");
+export const client = new Client(baseEndpoint + prefixPath);
 
 export const global = { connections: [] as Connection[], };
 


### PR DESCRIPTION
The goal of this PR is to allow the users to use URLs with prefix. 

What this code does : 
- Extract prefix path from the current window location.
- Append the detected prefix path to the base endpoint for client initialization.

For example, if your playground URL is "http://localhost:3000/myPrefix/playground", the Client requests will take into consideration this prefix. 

Of course, if any prefix are present, the Client URL will be the base one.

I created this PR because we have this use case for one of our project. 

Thanks a lot :) 

