### PR TITLE
sort message types for a clear view (Update JoinRoomForm.tsx)

### DIFF
--- a/src/components/JoinRoomForm.tsx
+++ b/src/components/JoinRoomForm.tsx
@@ -153,6 +153,8 @@ export function JoinRoomForm ({
 			onDisconnection(room.sessionId));
 
 		room.onMessage("__playground_message_types", (types) => {
+			// sort message types for a clear view
+			types.sort();
 			// global message types by room name
 			messageTypesByRoom[room.name] = types;
 


### PR DESCRIPTION
The message types in the Inspection Connection component are difficult to use because they appear in a random order if you have too many message types defined. Sorting them will improve clarity and make the component easier to use.

![image](https://github.com/user-attachments/assets/e2d4874a-194a-4ab2-b96e-61f8cfbcd29c)
